### PR TITLE
Handle case when sqlStatementResults doesn't have records field, for …

### DIFF
--- a/rds/index.js
+++ b/rds/index.js
@@ -9,7 +9,10 @@ export function toJsonObject(inputStr) {
   let perStatement = [];
   for (const { records, columnMetadata } of input.sqlStatementResults) {
     const statement = [];
-
+    if(typeof records === 'undefined' ){
+      perStatement.push({});
+      continue;
+    }
     for (const record of records) {
       const row = {};
       if (record.length !== columnMetadata.length) {


### PR DESCRIPTION
…example it contains result of update or insert statement. In this case AWS adds empty object to array